### PR TITLE
Copied formatting workflow from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: Run Unit Tests
         run: go test ./... -cover
-
-      - name: Exit tests
-        run: exit 0
     
   style:
     name: Style


### PR DESCRIPTION
removed the exit command from the workflow.